### PR TITLE
Update "Your name" to something more verbose

### DIFF
--- a/accounts/imap/package/contents/ui/ImapAccountSettings.qml
+++ b/accounts/imap/package/contents/ui/ImapAccountSettings.qml
@@ -70,12 +70,12 @@ Item {
             }
 
             Kube.Label {
-                text: "Name"
+                text: "Username"
                 Layout.alignment: Qt.AlignRight
             }
             Kube.TextField {
                 Layout.fillWidth: true
-                placeholderText: "Your name"
+                placeholderText: "The username as recognised by the imap server"
                 text: imapSettings.userName
                 onTextChanged: {
                     imapSettings.userName = text


### PR DESCRIPTION
"Your name" in ImapAccountSettings.qml gives virtually no additional information. I propose to change it to something more verbose and descriptive of what it's used for. The interface (as of now) is confusing as it is. Adding some clarification would be nice. 