### PR TITLE
README: fix a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ GPLV2+
 
 ## Getting involved
 
-www.kube.kde.org
+[kube.kde.org](https://kube.kde.org/)
 
 ## Extract translatable messages
 


### PR DESCRIPTION
kube.kde.org has no "www" version, attempting to access it results in DNS error.