### PR TITLE
Fix the testsuite when running in a deep directory.

### DIFF
--- a/cmake/modules/add_gpg_crypto_test.cmake
+++ b/cmake/modules/add_gpg_crypto_test.cmake
@@ -3,12 +3,27 @@
 # Redistribution and use is allowed according to the terms of the BSD license.
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
-set( MIMETREEPARSERRELPATH framework/src/domain/mime/mimetreeparser)
+if (UNIX)
+  # Use a symlink to make this path shorter since gpg-agent won't work if it's too long
+  # Non-unix platforms don't support symlinks
+  set( MIMETREEPARSERRELPATH mtp)
+else (UNIX)
+  set( MIMETREEPARSERRELPATH framework/src/domain/mime/mimetreeparser)
+endif (UNIX)
+
 set( GNUPGHOME ${CMAKE_BINARY_DIR}/${MIMETREEPARSERRELPATH}/tests/gnupg_home )
 add_definitions( -DGNUPGHOME="${GNUPGHOME}" )
 
+macro (ADD_MTP_SYMLINK)
+   if (UNIX)
+     add_custom_target(mtp_link ALL
+       COMMAND ${CMAKE_COMMAND} -E create_symlink framework/src/domain/mime/mimetreeparser ${CMAKE_BINARY_DIR}/mtp)
+   endif (UNIX)
+endmacro (ADD_MTP_SYMLINK)
+
 macro (ADD_GPG_CRYPTO_TEST _target _testname)
    if (UNIX)
+      add_dependencies(${_target} mtp_link)
       if (APPLE)
          set(_library_path_variable "DYLD_LIBRARY_PATH")
       elseif (CYGWIN)

--- a/framework/src/domain/mime/mimetreeparser/tests/CMakeLists.txt
+++ b/framework/src/domain/mime/mimetreeparser/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ include(ECMAddTests)
 
 add_executable(mimetreeparsertest mimetreeparsertest.cpp)
 add_gpg_crypto_test(mimetreeparsertest mimetreeparsertest)
+add_mtp_symlink()
 target_link_libraries(mimetreeparsertest
     kube_otp
     Qt5::Core


### PR DESCRIPTION
gpg-agent's socket must fix inside a sockaddr_un.sun_path which on Linux
is only 108 characters in length. Given that the fixed part of the socket
path is already 70 characters (i.e.
/framework/src/domain/mime/mimetreeparser/tests/gnupg_home/S.gpg-agent)
the variable portion can only be 38 characters, so something as
innocuous as /home/dan/rpmbuild/BUILD/kube-0.8.0/build/framework/src/domain/
mime/mimetreeparser/tests/gnupg_home/S.gpg-agent (an actual example from
a automatic build system) causes the mimetreeparsertest & others to fail
with "gpg-connect-agent: can't connect to the agent: File name too long"

This patch adds a symlink on Unix-like systems to make the socket length
shorter, giving much more room for the user portion of the path.

Note that I'm no expert in CMake and this could probably be done more
elegantly. It's also likely not perfect with respect to dependencies. Plus, the
whole idea of using a symlink for this seems suboptimal. But, it fixed the
issue I had.